### PR TITLE
Add pipeline for gontroller perf tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,14 +26,21 @@ The AWS account and domain used to host the BBL and CF foundation is currently o
 
 ## Automatic Setup / Destruction
 
-There are two Concourse pipelines for the automatic deployment and destruction of a CF foundation. Log on to Concourse with the "fly" CLI and upload the pipelines:
+There are two Concourse pipelines for the automatic deployment and destruction of a CF foundation. Log on to Concourse with the "fly" CLI and upload the pipelines. The "cf-perf-test" variables configure the pipelines for the default CF deployment. The "go-perf-test" variables are for the CF deployment with the new gontroller reimplementation.
 
 **NOTE**: The credentials which are required below are currently only available to SAP employees.
 
 ```bash
+# "cf.cfperftest.bndl.sapcloud.io" or "cf.goperftest.bndl.sapcloud.io"
+SYSTEM_DOMAIN=<domain>
+
 # find those in vault
+# aws/cf-perf-test-state-bucket-user or aws/go-perf-test-state-bucket-user
 read -s BBL_STATE_BUCKET_KEY_ID
 read -s BBL_STATE_BUCKET_KEY_SECRET
+
+# "cf-perf-test-state" or "go-perf-test-state"
+BBL_STATE_BUCKET_NAME=<bucket name>
 
 # find those in vault
 read -s GITHUB_USER
@@ -41,14 +48,18 @@ read -s GITHUB_EMAIL
 read -s GITHUB_TOKEN
 
 # find those in vault
+# aws/iaas-provider_bootstrap-cfperftest or aws/iaas-provider_bootstrap-goperftest
 read -s AWS_KEY_ID
 read -s AWS_KEY_SECRET
 
 read -s SLACK_URL
 
-fly -t <target> set-pipeline -p deploy-cf-performance-test \
+# pipeline name: "deploy-cf-performance-test" or "deploy-go-performance-test"
+fly -t <target> set-pipeline -p <pipeline name> \
+-v system-domain=$SYSTEM_DOMAIN \
 -v bbl-state-bucket-access-key-id=$BBL_STATE_BUCKET_KEY_ID \
--v bbl-state-bucket-access-key-secret=$BBL_KEY_SECRET \
+-v bbl-state-bucket-access-key-secret=$BBL_STATE_BUCKET_KEY_SECRET \
+-v bbl-state-bucket-name=$BBL_STATE_BUCKET_NAME \
 -v github-serviceuser-username=$GITHUB_USER \
 -v github-serviceuser-token=$GITHUB_TOKEN \
 -v github-serviceuser-email=$GITHUB_EMAIL \
@@ -57,9 +68,11 @@ fly -t <target> set-pipeline -p deploy-cf-performance-test \
 -v slack-notification-url=$SLACK_URL \
 -c ./concourse/deploy-cf-perftest.yml
 
-fly -t <target name> set-pipeline -p destroy-cf-performance-test
+# pipeline name: "destroy-cf-performance-test" or "destroy-go-performance-test"
+fly -t <target> set-pipeline -p <pipeline name> \
 -v bbl-state-bucket-access-key-id=$BBL_STATE_BUCKET_KEY_ID \
--v bbl-state-bucket-access-key-secret=$BBL_KEY_SECRET \
+-v bbl-state-bucket-access-key-secret=$BBL_STATE_BUCKET_KEY_SECRET \
+-v bbl-state-bucket-name=$BBL_STATE_BUCKET_NAME \
 -v github-serviceuser-username=$GITHUB_USER \
 -v github-serviceuser-token=$GITHUB_TOKEN \
 -v github-serviceuser-email=$GITHUB_EMAIL \

--- a/concourse/deploy-cf-perftest.yml
+++ b/concourse/deploy-cf-perftest.yml
@@ -17,12 +17,12 @@ resources:
       uri: https://github.com/cloudfoundry-incubator/cf-performance-tests-pipeline.git
       username: ((github-serviceuser-username))
       password: ((github-serviceuser-token))
-      branch: master # required for "put"
+      branch: main # required for "put"
   - name: bbl-state
     type: s3
     source:
       region_name: eu-central-1
-      bucket: cf-perf-test-state
+      bucket: ((bbl-state-bucket-name))
       versioned_file: bbl-state.tar.gz
       access_key_id: ((bbl-state-bucket-access-key-id))
       secret_access_key: ((bbl-state-bucket-access-key-secret))
@@ -50,7 +50,7 @@ resources:
     type: s3
     source:
       region_name: eu-central-1
-      bucket: cf-perf-test-state
+      bucket: ((bbl-state-bucket-name))
       versioned_file: integration_config.json
       access_key_id: ((bbl-state-bucket-access-key-id))
       secret_access_key: ((bbl-state-bucket-access-key-secret))
@@ -58,7 +58,7 @@ resources:
     type: s3
     source:
       region_name: eu-central-1
-      bucket: cf-perf-test-state
+      bucket: ((bbl-state-bucket-name))
       versioned_file: lb_certificate.tar.gz
       access_key_id: ((bbl-state-bucket-access-key-id))
       secret_access_key: ((bbl-state-bucket-access-key-secret))
@@ -87,7 +87,7 @@ jobs:
             source:
               repository: cloudfoundry/cf-deployment-concourse-tasks
             version:
-              digest: sha256:74c7c1be79082896a1f05a28aeed8a5f9fe30038d9e6b349779ccae8e26a5925
+              digest: sha256:90349a43f1a254d9e458a519fe2d3acc5c655d90ac82a418d009c923df0bcc26
           inputs:
             - name: cf-deployment-concourse-tasks  # - This repo
             - name: bbl-state  # - The S3 bucket containing bbl state
@@ -190,7 +190,7 @@ jobs:
             # - Can be either the key content or a path to the key
             # - If a path is provided, path is relative to the BBL_STATE_DIR
 
-            LB_DOMAIN: cf.cfperftest.bndl.sapcloud.io
+            LB_DOMAIN: ((system-domain))
             # - Required if `SKIP_LB_CREATION` is false
             # - The domain which bbl will register
 
@@ -261,7 +261,7 @@ jobs:
             source:
               repository: cloudfoundry/cf-deployment-concourse-tasks
             version:
-              digest: sha256:74c7c1be79082896a1f05a28aeed8a5f9fe30038d9e6b349779ccae8e26a5925
+              digest: sha256:90349a43f1a254d9e458a519fe2d3acc5c655d90ac82a418d009c923df0bcc26
 
           inputs:
             - name: bbl-state  # - The repo containing the Director's bbl state dir
@@ -285,7 +285,7 @@ jobs:
             # - Filepath to the manifest file within the cf-deployment resource
             # - The path is relative to root of the `cf-deployment` input
 
-            SYSTEM_DOMAIN: cf.cfperftest.bndl.sapcloud.io
+            SYSTEM_DOMAIN: ((system-domain))
             # - Required unless toolsmiths-env optional input is provided
             # - CF system base domain e.g. `my-cf.com`
 
@@ -403,7 +403,7 @@ jobs:
             source:
               repository: cloudfoundry/cf-deployment-concourse-tasks
             version:
-              digest: sha256:74c7c1be79082896a1f05a28aeed8a5f9fe30038d9e6b349779ccae8e26a5925
+              digest: sha256:90349a43f1a254d9e458a519fe2d3acc5c655d90ac82a418d009c923df0bcc26
 
           inputs:
             - name: bbl-state
@@ -413,7 +413,7 @@ jobs:
             path: cf-deployment-concourse-tasks/bosh-cleanup/task
 
           params:
-            BBL_STATE_DIR: bbl-state
+            BBL_STATE_DIR: state
             # - Path to the directory containing the `bbl-state.json` file
             # - The path is relative to the `bbl-state` input
             # - If blank or '.', uses `bbl-state` input as the location for bbl state
@@ -448,7 +448,7 @@ jobs:
             source:
               repository: cloudfoundry/cf-deployment-concourse-tasks
             version:
-              digest: sha256:74c7c1be79082896a1f05a28aeed8a5f9fe30038d9e6b349779ccae8e26a5925
+              digest: sha256:90349a43f1a254d9e458a519fe2d3acc5c655d90ac82a418d009c923df0bcc26
           inputs:
             - name: perf-test-repo
             - name: cf-performance-tests
@@ -524,7 +524,7 @@ jobs:
             source:
               repository: cloudfoundry/cf-deployment-concourse-tasks
             version:
-              digest: sha256:74c7c1be79082896a1f05a28aeed8a5f9fe30038d9e6b349779ccae8e26a5925
+              digest: sha256:90349a43f1a254d9e458a519fe2d3acc5c655d90ac82a418d009c923df0bcc26
           inputs:
             - name: cf-deployment-concourse-tasks
             - name: cf-acceptance-tests

--- a/concourse/destroy-cf-perftest.yml
+++ b/concourse/destroy-cf-perftest.yml
@@ -8,7 +8,7 @@ resources:
     type: s3
     source:
       region_name: eu-central-1
-      bucket: cf-perf-test-state
+      bucket: ((bbl-state-bucket-name))
       versioned_file: bbl-state.tar.gz
       access_key_id: ((bbl-state-bucket-access-key-id))
       secret_access_key: ((bbl-state-bucket-access-key-secret))


### PR DESCRIPTION
* make bucket name for bbl state configurable so that we can use the
  deploy and destroy pipelines for the regular and for the gontroller
perf tests
* make domain name configurable
* fix branch name to "main"
* update cf-deployment-concourse-tasks image to latest version (required
  to get correct Terraform version)