### PR TITLE
Fix elb setup

### DIFF
--- a/bbl-patches/terraform/elb-idle-timeout.tf
+++ b/bbl-patches/terraform/elb-idle-timeout.tf
@@ -1,0 +1,4 @@
+# required for longer elb idle timeout (default is 60 seconds)
+resource "aws_elb" "cf_router_lb" {
+  idle_timeout = 300
+}

--- a/concourse/deploy-cf-perftest.yml
+++ b/concourse/deploy-cf-perftest.yml
@@ -253,6 +253,7 @@ jobs:
 
   - name: bosh-deploy
     serial: true
+    serial_groups: [bosh-deploy-run-performance-tests]
     plan:
       - get: cf-deployment-concourse-tasks
       - get: bbl-state
@@ -440,6 +441,7 @@ jobs:
 
   - name: run-performance-tests
     serial: true
+    serial_groups: [bosh-deploy-run-performance-tests]
     plan:
       - get: perf-test-repo
       - get: bbl-state


### PR DESCRIPTION
Increase elb idle timeout (from default 60 seconds to 5 minutes) for long running performance tests and add lock to prevent cf update running simultaneously with tests