### PR TITLE
Enable /v3/security_groups for new Go CC

### DIFF
--- a/operations/deploy-gontroller.yml
+++ b/operations/deploy-gontroller.yml
@@ -9,9 +9,9 @@
   path: /releases/-
   value:
     name: "cloud-controller"
-    version: "0.0.21"
-    url: https://((sap_artifactory_user)):((sap_artifactory_password))@common.cdn.repositories.cloud.sap:443/build.milestones/com/sap/cp/cloudfoundry/cloudgontroller-boshrelease/0.0.21/cloudgontroller-boshrelease-0.0.21.tgz
-    sha1: "221341de38104b1db47cf96b4b24dbae6b7612c3"
+    version: "0.0.24"
+    url: https://((sap_artifactory_user)):((sap_artifactory_password))@common.cdn.repositories.cloud.sap:443/build.milestones/com/sap/cp/cloudfoundry/cloudgontroller-boshrelease/0.0.24/cloudgontroller-boshrelease-0.0.24.tgz
+    sha1: "234104aa3414466a8b5b3350a6b440be6226d490"
 - type: replace
   path: /instance_groups/-
   value:
@@ -75,7 +75,7 @@
               "/v3/buildpacks AND method GET":
                 servers: [127.0.0.1]
                 port: 8282
-              "/v3/security_groups/ AND method GET":
+              "/v3/security_groups AND method GET":
                 servers: [127.0.0.1]
                 port: 8282
               "/docs":
@@ -107,7 +107,5 @@
                 uris:
                   - api.((system_domain))/v3/info
                   - api.((system_domain))/v3/buildpacks
-                  # "security_groups" is not yet fully implemented
-                  # disable for now so that we have a green pipeline
-                  #- api.((system_domain))/v3/security_groups
+                  - api.((system_domain))/v3/security_groups
                   - api.((system_domain))/docs


### PR DESCRIPTION
The /v3/security_groups and /v3/security_groups/:guid endpoints are both
implemented in 0.0.24 as well as the X-Runtime header that these tests
use to measure execution time. We should now be able to route GET
requests to this endpoint to the new CC and measure the performance of
the new implementation