### PR TITLE
Split /v3/buildpacks and /v3/buildpacks/

### DIFF
--- a/operations/deploy-go-cf-api.yml
+++ b/operations/deploy-go-cf-api.yml
@@ -73,8 +73,14 @@
               "/v3/info":
                 servers: [127.0.0.1]
                 port: 8282
+              "/v3/buildpacks/":
+                additional_acls: [method GET]
+                servers: [127.0.0.1]
+                port: 8282
               "/v3/buildpacks":
-                additional_acls: [method GET POST]
+                additional_acls:
+                - method GET POST
+                - path_end /v3/buildpacks
                 servers: [127.0.0.1]
                 port: 8282
               "/v3/security_groups":


### PR DESCRIPTION
We don't want to send POST requests to /v3/buildpacks/* as this is the
bits upload endpoint that isn't implemented. Instead, only allow GETs to
that endpoint (i.e. /v3/buildpacks/:guid) and then allows GETs and POSTs
to /v3/buildpacks (no /:guid etc. allowed due to path_end flag)

This passed CATs when manually deployed https://bosh.ci.cloudfoundry.org/teams/cf-controlplane/pipelines/deploy-go-performance-test/jobs/cf-acceptance-test/builds/19.1