### PR TITLE
Add serial group to "bosh-delete" job

### DIFF
--- a/concourse/deploy-cf-perftest.yml
+++ b/concourse/deploy-cf-perftest.yml
@@ -596,6 +596,7 @@ jobs:
 
   - name: bosh-delete-cf-deployment
     serial: true
+    serial_groups: [bosh-deploy-run-performance-tests]
     plan:
       - get: cf-deployment-concourse-tasks
       - get: bbl-state


### PR DESCRIPTION
* only one of "bosh-deploy", "run-performance-tests" and
  "bosh-delete-cf-deployment" should run at a time