### PR TITLE
Exclude us-east-1e from availability zones

### DIFF
--- a/bbl-patches/terraform/azs_override.tf
+++ b/bbl-patches/terraform/azs_override.tf
@@ -1,0 +1,5 @@
+# us-east-1e does not support t3.micro instances required by the BOSH Director
+variable "availability_zones" {
+  type    = list(any)
+  default = ["us-east-1a", "us-east-1b", "us-east-1c", "us-east-1d", "us-east-1f"]
+}


### PR DESCRIPTION
BBL uses all AZs in a region by default. The `t3.micro` instance type used by the BOSH Director is not available in `us-east-1e`, causing consistent deployment failures.