### PR TITLE
Exclude us-east-1e from availability zones

### DIFF
--- a/bbl-patches/terraform/azs_override.tf
+++ b/bbl-patches/terraform/azs_override.tf
@@ -1,5 +1,0 @@
-# us-east-1e does not support t3.micro instances required by the BOSH Director
-variable "availability_zones" {
-  type    = list(any)
-  default = ["us-east-1a", "us-east-1b", "us-east-1c", "us-east-1d", "us-east-1f"]
-}

--- a/bbl-patches/vars/override-azs.tfvars
+++ b/bbl-patches/vars/override-azs.tfvars
@@ -1,0 +1,2 @@
+# us-east-1e does not support t3.micro instances required by the BOSH Director
+availability_zones = ["us-east-1a", "us-east-1b", "us-east-1c", "us-east-1d", "us-east-1f"]


### PR DESCRIPTION
BBL auto-detects all AZs in a region and passes them as an explicit terraform variable. The `t3.micro` instance type is not available in `us-east-1e`, causing consistent deployment failures.

Override via a `tfvars` file in the `vars` directory, which BBL picks up after its own `bbl.tfvars`.