### PR TITLE
Pin bosh subnet to first AZ

### DIFF
--- a/bbl-patches/terraform/bosh-subnet_override.tf
+++ b/bbl-patches/terraform/bosh-subnet_override.tf
@@ -1,0 +1,5 @@
+# AWS picks a random AZ for subnets without an explicit availability_zone.
+# us-east-1e does not support t3.micro, which is used by the jumpbox.
+resource "aws_subnet" "bosh_subnet" {
+  availability_zone = element(var.availability_zones, 0)
+}

--- a/bbl-patches/vars/override-azs.tfvars
+++ b/bbl-patches/vars/override-azs.tfvars
@@ -1,2 +1,0 @@
-# us-east-1e does not support t3.micro instances required by the BOSH Director
-availability_zones = ["us-east-1a", "us-east-1b", "us-east-1c", "us-east-1d", "us-east-1f"]


### PR DESCRIPTION
AWS picks a random AZ for subnets without an explicit `availability_zone`. `us-east-1e` does not support `t3.micro` which is used by the jumpbox. Pin the bosh subnet to the first AZ instead of excluding `us-east-1e` entirely.